### PR TITLE
문제 필터링 기능 개선 및 이메일 발송 성능 최적화

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM mokapi/mokapi:latest
+
+COPY ./smtp.yaml /demo/
+
+CMD ["--Providers.File.Directory=/demo"]

--- a/smtp.yaml
+++ b/smtp.yaml
@@ -1,0 +1,4 @@
+smtp: '1.0'
+info:
+  title: Mokapi's Mail Server
+server: smtp://127.0.0.1:25

--- a/src/main/java/org/janggo/pseveryday/PsEverydayApplication.java
+++ b/src/main/java/org/janggo/pseveryday/PsEverydayApplication.java
@@ -3,6 +3,7 @@ package org.janggo.pseveryday;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication

--- a/src/main/java/org/janggo/pseveryday/application/mail/service/MailService.java
+++ b/src/main/java/org/janggo/pseveryday/application/mail/service/MailService.java
@@ -5,6 +5,7 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.janggo.pseveryday.domain.problem.dto.SolvedAcResponse;
+import org.janggo.pseveryday.domain.problem.entity.Problem;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -32,7 +33,7 @@ public class MailService {
         sendMail("📌 PS Everyday - 이메일 인증 코드", email, "mail/verification-mail", variables);
     }
 
-    public void sendProblemMail(String email, SolvedAcResponse.ProblemItem problem) {
+    public void sendProblemMail(String email, Problem problem) {
         Map<String, Object> variables = Map.of(
                 "email", email,
                 "problem", problem,

--- a/src/main/java/org/janggo/pseveryday/application/mail/service/MailService.java
+++ b/src/main/java/org/janggo/pseveryday/application/mail/service/MailService.java
@@ -4,16 +4,17 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.janggo.pseveryday.domain.problem.dto.SolvedAcResponse;
 import org.janggo.pseveryday.domain.problem.entity.Problem;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Service
@@ -33,6 +34,7 @@ public class MailService {
         sendMail("📌 PS Everyday - 이메일 인증 코드", email, "mail/verification-mail", variables);
     }
 
+    @Async
     public void sendProblemMail(String email, Problem problem) {
         Map<String, Object> variables = Map.of(
                 "email", email,
@@ -41,6 +43,7 @@ public class MailService {
         );
         sendMail("🎯 오늘의 알고리즘 문제", email, "mail/problem-mail", variables);
     }
+
 
     public void sendGreetingMail(String email) {
         Map<String, Object> variables = Map.of("email", email);

--- a/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
+++ b/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
@@ -25,11 +25,12 @@ public class ProblemScheduler {
     private final MailService mailService;
     private final SubscriberRepository subscriberRepository;
 
-    @Scheduled(cron = "* * 8 * * *") // 매일 오전 8시 실행
+    @Scheduled(cron = "*/5 * * * * *") // 매일 오전 8시 실행
     public void scheduleRandomProblemMail() {
         List<Subscriber> subscribers = subscriberRepository.findAll();
 
         for(Subscriber subscriber: subscribers){
+            log.info("min, max = {}, {}", subscriber.getTierPreference().getMinTier(), subscriber.getTierPreference().getMaxTier());
             // 구독자의 선호 난이도 범위에 맞는 문제들 조회
             List<Problem> problems = problemRepository.findByLevelBetweenWithTags(
                     subscriber.getTierPreference().getMinTier(),

--- a/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
+++ b/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
@@ -3,6 +3,8 @@ package org.janggo.pseveryday.application.problem.scheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.janggo.pseveryday.application.mail.service.MailService;
+import org.janggo.pseveryday.domain.problem.entity.Problem;
+import org.janggo.pseveryday.domain.problem.repository.ProblemRepository;
 import org.janggo.pseveryday.external.solvedac.service.SolvedAcService;
 import org.janggo.pseveryday.domain.problem.dto.SolvedAcResponse;
 import org.janggo.pseveryday.domain.subscriber.entity.Subscriber;
@@ -12,14 +14,14 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Random;
 
 @Component
 @Slf4j
 @EnableScheduling
 @RequiredArgsConstructor
 public class ProblemScheduler {
-
-    private final SolvedAcService solvedAcService;
+    private final ProblemRepository problemRepository;
     private final MailService mailService;
     private final SubscriberRepository subscriberRepository;
 
@@ -27,10 +29,22 @@ public class ProblemScheduler {
     public void scheduleRandomProblemMail() {
         List<Subscriber> subscribers = subscriberRepository.findAll();
 
-        SolvedAcResponse.ProblemItem randomProblem = solvedAcService.getRandomProblem();
-
         for(Subscriber subscriber: subscribers){
-            log.info("구독지 : {}", subscriber.getEmail());
+            // 구독자의 선호 난이도 범위에 맞는 문제들 조회
+            List<Problem> problems = problemRepository.findByLevelBetweenWithTags(
+                    subscriber.getTierPreference().getMinTier(),
+                    subscriber.getTierPreference().getMaxTier()
+            );
+
+            if (problems.isEmpty()) {
+                log.warn("구독자 {}에게 추천할 문제가 없습니다.", subscriber.getEmail());
+                continue;
+            }
+
+            // 랜덤으로 문제 선택
+            Problem randomProblem = problems.get(new Random().nextInt(problems.size()));
+
+            log.info("구독자 {}에게 문제 추천: {} (Level : {})", subscriber.getEmail(), randomProblem.getTitleKo(), randomProblem.getLevel());
             mailService.sendProblemMail(subscriber.getEmail(), randomProblem);
         }
     }

--- a/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
+++ b/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
@@ -5,8 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.janggo.pseveryday.application.mail.service.MailService;
 import org.janggo.pseveryday.domain.problem.entity.Problem;
 import org.janggo.pseveryday.domain.problem.repository.ProblemRepository;
-import org.janggo.pseveryday.external.solvedac.service.SolvedAcService;
-import org.janggo.pseveryday.domain.problem.dto.SolvedAcResponse;
 import org.janggo.pseveryday.domain.subscriber.entity.Subscriber;
 import org.janggo.pseveryday.domain.subscriber.repository.SubscriberRepository;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -27,7 +25,7 @@ public class ProblemScheduler {
     private final MailService mailService;
     private final SubscriberRepository subscriberRepository;
 
-    @Scheduled(cron = "*/5 * * * * *")
+    @Scheduled(cron = "0 0 8 * * *", zone = "Asia/Seoul")
     @Transactional(readOnly = true)
     public void scheduleRandomProblemMail() {
         List<Subscriber> subscribers = subscriberRepository.findAll();
@@ -38,27 +36,8 @@ public class ProblemScheduler {
             // 선호 티어와 태그 정보 확인
             boolean hasTierPreference = subscriber.getTierPreference() != null;
             boolean hasTagPreference = !subscriber.getTagPreferences().isEmpty();
-
-            if (hasTierPreference && hasTagPreference) {
-                // 선호 티어와 태그 모두 있는 경우
-                problems = problemRepository.findProblemsBySubscriberPreferences(
-                        subscriber.getTierPreference().getMinTier(),
-                        subscriber.getTierPreference().getMaxTier(),
-                        subscriber.getId()
-                );
-            } else if (hasTierPreference) {
-                // 선호 티어만 있는 경우
-                problems = problemRepository.findByLevelBetween(
-                        subscriber.getTierPreference().getMinTier(),
-                        subscriber.getTierPreference().getMaxTier()
-                );
-            } else if (hasTagPreference) {
-                // 선호 태그만 있는 경우
-                problems = problemRepository.findByTagPreferences(subscriber.getId());
-            } else {
-                // 둘 다 없는 경우
-                problems = problemRepository.findAll();
-            }
+            log.info("{}의 선호 태그 : {}", subscriber.getEmail(), subscriber.getTagPreferenceNames());
+            problems = filterProblems(subscriber, hasTierPreference, hasTagPreference);
 
             if (problems.isEmpty()) {
                 log.warn("구독자 {}에게 추천할 문제가 없습니다.", subscriber.getEmail());
@@ -78,5 +57,30 @@ public class ProblemScheduler {
 
             mailService.sendProblemMail(subscriber.getEmail(), randomProblem);
         }
+    }
+
+    private List<Problem> filterProblems(Subscriber subscriber, boolean hasTierPreference, boolean hasTagPreference) {
+        List<Problem> problems;
+        if (hasTierPreference && hasTagPreference) {
+            // 선호 티어와 태그 모두 있는 경우
+            problems = problemRepository.findProblemsBySubscriberPreferences(
+                    subscriber.getTierPreference().getMinTier(),
+                    subscriber.getTierPreference().getMaxTier(),
+                    subscriber.getId()
+            );
+        } else if (hasTierPreference) {
+            // 선호 티어만 있는 경우
+            problems = problemRepository.findByLevelBetween(
+                    subscriber.getTierPreference().getMinTier(),
+                    subscriber.getTierPreference().getMaxTier()
+            );
+        } else if (hasTagPreference) {
+            // 선호 태그만 있는 경우
+            problems = problemRepository.findByTagPreferences(subscriber.getId());
+        } else {
+            // 둘 다 없는 경우
+            problems = problemRepository.findAll();
+        }
+        return problems;
     }
 }

--- a/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
+++ b/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
@@ -26,25 +26,43 @@ public class ProblemScheduler {
     private final MailService mailService;
     private final SubscriberRepository subscriberRepository;
 
-    @Scheduled(cron = "*/5 * * * * *") // 매일 오전 8시 실행
+    @Scheduled(cron = "*/5 * * * * *")
     public void scheduleRandomProblemMail() {
         List<Subscriber> subscribers = subscriberRepository.findAll();
 
         for(Subscriber subscriber: subscribers){
-            log.info("min, max = {}, {}", subscriber.getTierPreference().getMinTier(), subscriber.getTierPreference().getMaxTier());
-            // 구독자의 선호 난이도 범위에 맞는 문제들 조회
-            List<Problem> problems = problemRepository.findProblemsBySubscriberPreferences(
-                    subscriber.getTierPreference().getMinTier(),
-                    subscriber.getTierPreference().getMaxTier(),
-                    subscriber.getId()
-            );
+            List<Problem> problems;
+
+            // 선호 티어와 태그 정보 확인
+            boolean hasTierPreference = subscriber.getTierPreference() != null;
+            boolean hasTagPreference = !subscriber.getTagPreferences().isEmpty();
+
+            if (hasTierPreference && hasTagPreference) {
+                // 선호 티어와 태그 모두 있는 경우
+                problems = problemRepository.findProblemsBySubscriberPreferences(
+                        subscriber.getTierPreference().getMinTier(),
+                        subscriber.getTierPreference().getMaxTier(),
+                        subscriber.getId()
+                );
+            } else if (hasTierPreference) {
+                // 선호 티어만 있는 경우
+                problems = problemRepository.findByLevelBetween(
+                        subscriber.getTierPreference().getMinTier(),
+                        subscriber.getTierPreference().getMaxTier()
+                );
+            } else if (hasTagPreference) {
+                // 선호 태그만 있는 경우
+                problems = problemRepository.findByTagPreferences(subscriber.getId());
+            } else {
+                // 둘 다 없는 경우
+                problems = problemRepository.findAll();
+            }
 
             if (problems.isEmpty()) {
                 log.warn("구독자 {}에게 추천할 문제가 없습니다.", subscriber.getEmail());
                 continue;
             }
 
-            // 랜덤으로 문제 선택
             Problem randomProblem = problems.get(new Random().nextInt(problems.size()));
 
             log.info("구독자 {}에게 문제 추천: {} (Level: {}, Tags: {})",

--- a/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
+++ b/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
@@ -12,8 +12,10 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 @Component
@@ -36,7 +38,9 @@ public class ProblemScheduler {
             // 선호 티어와 태그 정보 확인
             boolean hasTierPreference = subscriber.getTierPreference() != null;
             boolean hasTagPreference = !subscriber.getTagPreferences().isEmpty();
+
             log.info("{}의 선호 태그 : {}", subscriber.getEmail(), subscriber.getTagPreferenceNames());
+
             problems = filterProblems(subscriber, hasTierPreference, hasTagPreference);
 
             if (problems.isEmpty()) {

--- a/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
+++ b/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 @Component
 @Slf4j
@@ -32,9 +33,10 @@ public class ProblemScheduler {
         for(Subscriber subscriber: subscribers){
             log.info("min, max = {}, {}", subscriber.getTierPreference().getMinTier(), subscriber.getTierPreference().getMaxTier());
             // 구독자의 선호 난이도 범위에 맞는 문제들 조회
-            List<Problem> problems = problemRepository.findByLevelBetweenWithTags(
+            List<Problem> problems = problemRepository.findProblemsBySubscriberPreferences(
                     subscriber.getTierPreference().getMinTier(),
-                    subscriber.getTierPreference().getMaxTier()
+                    subscriber.getTierPreference().getMaxTier(),
+                    subscriber.getId()
             );
 
             if (problems.isEmpty()) {
@@ -45,7 +47,15 @@ public class ProblemScheduler {
             // 랜덤으로 문제 선택
             Problem randomProblem = problems.get(new Random().nextInt(problems.size()));
 
-            log.info("구독자 {}에게 문제 추천: {} (Level : {})", subscriber.getEmail(), randomProblem.getTitleKo(), randomProblem.getLevel());
+            log.info("구독자 {}에게 문제 추천: {} (Level: {}, Tags: {})",
+                    subscriber.getEmail(),
+                    randomProblem.getTitleKo(),
+                    randomProblem.getLevel(),
+                    randomProblem.getProblemTags().stream()
+                            .map(pt -> pt.getTag().getDisplayName())
+                            .collect(Collectors.joining(", "))
+            );
+
             mailService.sendProblemMail(subscriber.getEmail(), randomProblem);
         }
     }

--- a/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
+++ b/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
@@ -27,7 +27,7 @@ public class ProblemScheduler {
     private final MailService mailService;
     private final SubscriberRepository subscriberRepository;
 
-    @Scheduled(cron = "0 0 8 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "*/10 * * * * *", zone = "Asia/Seoul")
     @Transactional(readOnly = true)
     public void scheduleRandomProblemMail() {
         List<Subscriber> subscribers = subscriberRepository.findAll();

--- a/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
+++ b/src/main/java/org/janggo/pseveryday/application/problem/scheduler/ProblemScheduler.java
@@ -12,6 +12,7 @@ import org.janggo.pseveryday.domain.subscriber.repository.SubscriberRepository;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Random;
@@ -27,6 +28,7 @@ public class ProblemScheduler {
     private final SubscriberRepository subscriberRepository;
 
     @Scheduled(cron = "*/5 * * * * *")
+    @Transactional(readOnly = true)
     public void scheduleRandomProblemMail() {
         List<Subscriber> subscribers = subscriberRepository.findAll();
 

--- a/src/main/java/org/janggo/pseveryday/application/subscriber/service/SubscribeService.java
+++ b/src/main/java/org/janggo/pseveryday/application/subscriber/service/SubscribeService.java
@@ -27,10 +27,9 @@ public class SubscribeService {
     /**
      * 이메일 등록 및 인증 코드 전송
      */
-    public String sendVerificationCode(String email) {
+    public void sendVerificationCode(String email) {
         String verificationCode = verificationService.generationVerificationCode(email);
         mailService.sendVerifyMail(email, verificationCode);
-        return verificationCode;
     }
 
     /**

--- a/src/main/java/org/janggo/pseveryday/config/AsyncConfig.java
+++ b/src/main/java/org/janggo/pseveryday/config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package org.janggo.pseveryday.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);  // 기본 실행 스레드 수
+        executor.setMaxPoolSize(20);  // 최대 스레드 수
+        executor.setQueueCapacity(500);  // 작업 대기 큐 크기
+        executor.setThreadNamePrefix("MailAsync-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);  // 종료 시 최대 1분간 대기
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/org/janggo/pseveryday/domain/problem/dto/ProblemLevel.java
+++ b/src/main/java/org/janggo/pseveryday/domain/problem/dto/ProblemLevel.java
@@ -5,68 +5,52 @@ import lombok.Getter;
 
 @Getter
 public enum ProblemLevel {
-    UNRATED(0, "Unrated"),
-    BRONZE_V(1, "Bronze V"),
-    BRONZE_IV(2, "Bronze IV"),
-    BRONZE_III(3, "Bronze III"),
-    BRONZE_II(4, "Bronze II"),
-    BRONZE_I(5, "Bronze I"),
-    SILVER_V(6, "Silver V"),
-    SILVER_IV(7, "Silver IV"),
-    SILVER_III(8, "Silver III"),
-    SILVER_II(9, "Silver II"),
-    SILVER_I(10, "Silver I"),
-    GOLD_V(11, "Gold V"),
-    GOLD_IV(12, "Gold IV"),
-    GOLD_III(13, "Gold III"),
-    GOLD_II(14, "Gold II"),
-    GOLD_I(15, "Gold I"),
-    PLATINUM_V(16, "Platinum V"),
-    PLATINUM_IV(17, "Platinum IV"),
-    PLATINUM_III(18, "Platinum III"),
-    PLATINUM_II(19, "Platinum II"),
-    PLATINUM_I(20, "Platinum I"),
-    DIAMOND_V(21, "Diamond V"),
-    DIAMOND_IV(22, "Diamond IV"),
-    DIAMOND_III(23, "Diamond III"),
-    DIAMOND_II(24, "Diamond II"),
-    DIAMOND_I(25, "Diamond I"),
-    RUBY_V(26, "Ruby V"),
-    RUBY_IV(27, "Ruby IV"),
-    RUBY_III(28, "Ruby III"),
-    RUBY_II(29, "Ruby II"),
-    RUBY_I(30, "Ruby I");
+    UNRATED(0, "Unrated", "#888888"),
+    BRONZE_V(1, "Bronze V", "#CD7F32"),
+    BRONZE_IV(2, "Bronze IV", "#CD7F32"),
+    BRONZE_III(3, "Bronze III", "#CD7F32"),
+    BRONZE_II(4, "Bronze II", "#CD7F32"),
+    BRONZE_I(5, "Bronze I", "#CD7F32"),
+    SILVER_V(6, "Silver V", "#C0C0C0"),
+    SILVER_IV(7, "Silver IV", "#C0C0C0"),
+    SILVER_III(8, "Silver III", "#C0C0C0"),
+    SILVER_II(9, "Silver II", "#C0C0C0"),
+    SILVER_I(10, "Silver I", "#C0C0C0"),
+    GOLD_V(11, "Gold V", "#FFD700"),
+    GOLD_IV(12, "Gold IV", "#FFD700"),
+    GOLD_III(13, "Gold III", "#FFD700"),
+    GOLD_II(14, "Gold II", "#FFD700"),
+    GOLD_I(15, "Gold I", "#FFD700"),
+    PLATINUM_V(16, "Platinum V", "#00E5EE"),
+    PLATINUM_IV(17, "Platinum IV", "#00E5EE"),
+    PLATINUM_III(18, "Platinum III", "#00E5EE"),
+    PLATINUM_II(19, "Platinum II", "#00E5EE"),
+    PLATINUM_I(20, "Platinum I", "#00E5EE"),
+    DIAMOND_V(21, "Diamond V", "#1E90FF"),
+    DIAMOND_IV(22, "Diamond IV", "#1E90FF"),
+    DIAMOND_III(23, "Diamond III", "#1E90FF"),
+    DIAMOND_II(24, "Diamond II", "#1E90FF"),
+    DIAMOND_I(25, "Diamond I", "#1E90FF"),
+    RUBY_V(26, "Ruby V", "#E0115F"),
+    RUBY_IV(27, "Ruby IV", "#E0115F"),
+    RUBY_III(28, "Ruby III", "#E0115F"),
+    RUBY_II(29, "Ruby II", "#E0115F"),
+    RUBY_I(30, "Ruby I", "#E0115F");
 
     private final int level;
     private final String displayName;
+    private final String color;
 
-    ProblemLevel(int level, String displayName) {
+    ProblemLevel(int level, String displayName, String color) {
         this.level = level;
         this.displayName = displayName;
-    }
-
-    public String getColor(int level) {
-        if (level >= 1 && level <= 5) { // Bronze
-            return "#CD7F32"; // 브론즈색 (청동)
-        } else if (level >= 6 && level <= 10) { // Silver
-            return "#C0C0C0"; // 실버색 (은색)
-        } else if (level >= 11 && level <= 15) { // Gold
-            return "#FFD700"; // 골드색
-        } else if (level >= 16 && level <= 20) { // Platinum
-            return "#00E5EE"; // 플래티넘색
-        } else if (level >= 21 && level <= 25) { // Diamond
-            return "#1E90FF"; // 다이아색
-        } else if (level >= 26 && level <= 30) { // Ruby
-            return "#E0115F"; // 루비색
-        } else { // Unrated or default
-            return "#888888"; // 기본값 (회색)
-        }
+        this.color = color;
     }
 
     @JsonCreator
     public static ProblemLevel fromLevel(int level) {
-        for (ProblemLevel problemLevel : ProblemLevel.values()) {
-            if (problemLevel.getLevel() == level) {
+        for (ProblemLevel problemLevel : values()) {
+            if (problemLevel.level == level) {
                 return problemLevel;
             }
         }

--- a/src/main/java/org/janggo/pseveryday/domain/problem/entity/Problem.java
+++ b/src/main/java/org/janggo/pseveryday/domain/problem/entity/Problem.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.janggo.pseveryday.domain.problem.dto.ProblemLevel;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -37,5 +38,9 @@ public class Problem {
     public void addTag(Tag tag) {
         ProblemTag problemTag = new ProblemTag(this, tag);
         this.problemTags.add(problemTag);
+    }
+
+    public ProblemLevel getProblemLevel(){
+        return ProblemLevel.fromLevel(this.level);
     }
 }

--- a/src/main/java/org/janggo/pseveryday/domain/problem/entity/Tag.java
+++ b/src/main/java/org/janggo/pseveryday/domain/problem/entity/Tag.java
@@ -18,6 +18,7 @@ public class Tag {
     private Long id;
 
     String displayName;
+    @Column(name = "tag_key")
     private String key;
 
     @OneToMany(mappedBy = "tag", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/org/janggo/pseveryday/domain/problem/entity/Tag.java
+++ b/src/main/java/org/janggo/pseveryday/domain/problem/entity/Tag.java
@@ -18,6 +18,7 @@ public class Tag {
     private Long id;
 
     String displayName;
+
     @Column(name = "tag_key")
     private String key;
 

--- a/src/main/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepository.java
@@ -1,7 +1,9 @@
 package org.janggo.pseveryday.domain.problem.repository;
 
+import feign.Param;
 import org.janggo.pseveryday.domain.problem.entity.Problem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +12,7 @@ import java.util.List;
 @Repository
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
     List<Problem> findByLevelBetween(int minLevel, int maxLevel);
+
+    @Query("SELECT p FROM Problem p JOIN FETCH p.problemTags pt JOIN FETCH pt.tag WHERE p.level BETWEEN :minLevel AND :maxLevel")
+    List<Problem> findByLevelBetweenWithTags(@Param("minLevel") int minLevel, @Param("maxLevel") int maxLevel);
 }

--- a/src/main/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepository.java
@@ -21,4 +21,13 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
             @Param("minLevel") int minLevel,
             @Param("maxLevel") int maxLevel,
             @Param("subscriberId") Long subscriberId);
+
+    @Query("SELECT DISTINCT p FROM Problem p " +
+            "JOIN FETCH p.problemTags pt " +
+            "JOIN FETCH pt.tag t " +
+            "WHERE t.id IN (SELECT tp.tag.id FROM TagPreference tp " +
+            "              WHERE tp.subscriber.id = :subscriberId)")
+    List<Problem> findByTagPreferences(@Param("subscriberId") Long subscriberId);
+
+    List<Problem> findByLevelBetween(int minLevel, int maxLevel);
 }

--- a/src/main/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepository.java
@@ -1,9 +1,9 @@
 package org.janggo.pseveryday.domain.problem.repository;
 
-import feign.Param;
 import org.janggo.pseveryday.domain.problem.entity.Problem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/src/main/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepository.java
@@ -11,8 +11,14 @@ import java.util.List;
 // Problem 저장소
 @Repository
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
-    List<Problem> findByLevelBetween(int minLevel, int maxLevel);
-
-    @Query("SELECT p FROM Problem p JOIN FETCH p.problemTags pt JOIN FETCH pt.tag WHERE p.level BETWEEN :minLevel AND :maxLevel")
-    List<Problem> findByLevelBetweenWithTags(@Param("minLevel") int minLevel, @Param("maxLevel") int maxLevel);
+    @Query("SELECT DISTINCT p FROM Problem p " +
+            "JOIN FETCH p.problemTags pt " +
+            "JOIN FETCH pt.tag t " +
+            "WHERE p.level BETWEEN :minLevel AND :maxLevel " +
+            "AND t.id IN (SELECT tp.tag.id FROM TagPreference tp " +
+            "            WHERE tp.subscriber.id = :subscriberId)")
+    List<Problem> findProblemsBySubscriberPreferences(
+            @Param("minLevel") int minLevel,
+            @Param("maxLevel") int maxLevel,
+            @Param("subscriberId") Long subscriberId);
 }

--- a/src/main/java/org/janggo/pseveryday/domain/subscriber/repository/SubscriberRepository.java
+++ b/src/main/java/org/janggo/pseveryday/domain/subscriber/repository/SubscriberRepository.java
@@ -1,12 +1,21 @@
 package org.janggo.pseveryday.domain.subscriber.repository;
 
 import org.janggo.pseveryday.domain.subscriber.entity.Subscriber;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SubscriberRepository extends JpaRepository<Subscriber, Long> {
+
+    @EntityGraph(attributePaths = {
+            "tagPreferences",
+            "tagPreferences.tag"
+    })
+    List<Subscriber> findAll();
+
     boolean existsByEmail(String email);
 
     @Transactional

--- a/src/main/java/org/janggo/pseveryday/domain/subscriber/repository/TagPreferenceRepository.java
+++ b/src/main/java/org/janggo/pseveryday/domain/subscriber/repository/TagPreferenceRepository.java
@@ -1,0 +1,7 @@
+package org.janggo.pseveryday.domain.subscriber.repository;
+
+import org.janggo.pseveryday.domain.subscriber.entity.TagPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagPreferenceRepository extends JpaRepository<TagPreference, Long> {
+}

--- a/src/main/resources/templates/mail/problem-mail.html
+++ b/src/main/resources/templates/mail/problem-mail.html
@@ -13,7 +13,7 @@
     <div style="background: #e3f2fd; padding: 15px; border-radius: 8px; margin: 20px 0;">
         <h3 style="color: #007bff; font-size: 20px;" th:text="${problem.titleKo}"></h3>
         <p style="font-size: 16px; color: #333;">
-            <b>난이도: <span th:style="'color:' + ${problem.problemLevel.getColor(problem.level)}" th:text="${problem.problemLevel.getDisplayName()}"></span> </b>
+            <b>난이도: <span th:style="'color:' + ${problem.problemLevel.color}" th:text="${problem.problemLevel.displayName}"></span> </b>
         </p>
         <a th:href="${link}" style="display: inline-block; margin-top: 10px; padding: 10px 20px; color: #ffffff; background: #007bff; text-decoration: none; border-radius: 5px; font-weight: bold;">
             🔗 문제 풀러 가기

--- a/src/main/resources/templates/mail/problem-mail.html
+++ b/src/main/resources/templates/mail/problem-mail.html
@@ -13,7 +13,7 @@
     <div style="background: #e3f2fd; padding: 15px; border-radius: 8px; margin: 20px 0;">
         <h3 style="color: #007bff; font-size: 20px;" th:text="${problem.titleKo}"></h3>
         <p style="font-size: 16px; color: #333;">
-            <b>난이도: <span th:style="'color:' + ${problem.level.getColor(problem.level.getLevel())}" th:text="${problem.level.getDisplayName()}"></span> </b>
+            <b>난이도: <span th:style="'color:' + ${problem.problemLevel.getColor(problem.level)}" th:text="${problem.problemLevel.getDisplayName()}"></span> </b>
         </p>
         <a th:href="${link}" style="display: inline-block; margin-top: 10px; padding: 10px 20px; color: #ffffff; background: #007bff; text-decoration: none; border-radius: 5px; font-weight: bold;">
             🔗 문제 풀러 가기

--- a/src/test/java/org/janggo/pseveryday/application/problem/scheduler/ProblemSchedulerTest.java
+++ b/src/test/java/org/janggo/pseveryday/application/problem/scheduler/ProblemSchedulerTest.java
@@ -1,0 +1,57 @@
+package org.janggo.pseveryday.application.problem.scheduler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.janggo.pseveryday.application.mail.service.MailService;
+import org.janggo.pseveryday.util.TestSubscriberGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.Mockito.*;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class ProblemSchedulerTest {
+
+    @Autowired
+    private TestSubscriberGenerator testSubscriberGenerator;
+
+    @Autowired
+    private ProblemScheduler problemScheduler;
+
+    @Autowired
+    private MailService mailService;
+
+    @ParameterizedTest
+    @ValueSource(ints = {10, 100, 1000})
+    @DisplayName("사용자 수에 따른 문제 선별 및 발송 시간 측정")
+    void measureExecutionTime(int subscriberCount) {
+        testSubscriberGenerator.generateTestSubscribers(subscriberCount);
+
+//        doNothing().when(mailService).sendProblemMail(anyString(), any());
+
+        long start = System.currentTimeMillis();
+        problemScheduler.scheduleRandomProblemMail();
+        long end = System.currentTimeMillis();
+
+        log.info("{}명 - 실행 시간: {}ms", subscriberCount, (end - start));
+    }
+
+//    @TestConfiguration
+//    static class MockMailServiceConfig {
+//        @Bean
+//        @Primary // 기존 Bean 대신 이 Bean을 우선적으로 사용하게 함
+//        public MailService mailService() {
+//            return mock(MailService.class);
+//        }
+//    }
+}

--- a/src/test/java/org/janggo/pseveryday/application/problem/scheduler/ProblemSchedulerTest.java
+++ b/src/test/java/org/janggo/pseveryday/application/problem/scheduler/ProblemSchedulerTest.java
@@ -8,13 +8,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.mockito.Mockito.*;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
 
 @Slf4j
 @SpringBootTest
@@ -45,6 +45,8 @@ class ProblemSchedulerTest {
 
         log.info("{}명 - 실행 시간: {}ms", subscriberCount, (end - start));
     }
+
+
 
 //    @TestConfiguration
 //    static class MockMailServiceConfig {

--- a/src/test/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepositoryTest.java
+++ b/src/test/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepositoryTest.java
@@ -1,0 +1,90 @@
+package org.janggo.pseveryday.domain.problem.repository;
+
+import org.janggo.pseveryday.application.mail.service.MailService;
+import org.janggo.pseveryday.domain.problem.entity.Problem;
+import org.janggo.pseveryday.domain.problem.entity.Tag;
+import org.janggo.pseveryday.domain.subscriber.entity.Subscriber;
+import org.janggo.pseveryday.domain.subscriber.entity.TierPreference;
+import org.janggo.pseveryday.domain.subscriber.repository.SubscriberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@DataJpaTest
+@Transactional
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ProblemRepositoryTest {
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private SubscriberRepository subscriberRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Mock
+    private MailService mailService;
+
+    @Test
+    @DisplayName("구독자의 선호 티어와 태그에 맞는 문제 조회 테스트")
+    void findProblemsBySubscriberPreferences() {
+        // given
+        // 1. 태그 생성
+        Tag tag1 = new Tag("구현", "implementation");
+        Tag tag2 = new Tag("그리디", "greedy");
+        tagRepository.save(tag1);
+        tagRepository.save(tag2);
+
+        // 2. 구독자 생성 및 선호 설정
+        Subscriber subscriber = new Subscriber("test@example.com", new TierPreference(1, 5)); // Bronze V ~ Bronze I
+        subscriber.addTagPreference(tag1);
+        subscriber.addTagPreference(tag2);
+        subscriberRepository.save(subscriber);
+
+        // 3. 문제 생성
+        Problem problem1 = new Problem(1L, "문제1", 1); // Bronze V
+        problem1.addTag(tag1);
+        problemRepository.save(problem1);
+
+        Problem problem2 = new Problem(2L, "문제2", 3); // Bronze III
+        problem2.addTag(tag2);
+        problemRepository.save(problem2);
+
+        Problem problem3 = new Problem(3L, "문제3", 6); // Silver V (선호 티어 범위 밖)
+        problem3.addTag(tag1);
+        problemRepository.save(problem3);
+
+        // when
+        List<Problem> problems = problemRepository.findProblemsBySubscriberPreferences(
+                subscriber.getTierPreference().getMinTier(),
+                subscriber.getTierPreference().getMaxTier(),
+                subscriber.getId()
+        );
+
+        // then
+        assertThat(problems).hasSize(2); // Bronze V와 Bronze III 문제만 포함
+        assertThat(problems).extracting("problemId")
+                .containsExactlyInAnyOrder(1L, 2L);
+
+        // 각 문제의 태그 확인
+        for (Problem problem : problems) {
+            assertThat(problem.getProblemTags()).isNotEmpty();
+
+            assertThat(problem.getProblemTags().stream()
+                    .map(pt -> pt.getTag().getDisplayName())
+                    .collect(Collectors.toList()))
+                    .containsAnyOf("구현", "그리디");
+        }
+    }
+}

--- a/src/test/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepositoryTest.java
+++ b/src/test/java/org/janggo/pseveryday/domain/problem/repository/ProblemRepositoryTest.java
@@ -6,6 +6,7 @@ import org.janggo.pseveryday.domain.problem.entity.Tag;
 import org.janggo.pseveryday.domain.subscriber.entity.Subscriber;
 import org.janggo.pseveryday.domain.subscriber.entity.TierPreference;
 import org.janggo.pseveryday.domain.subscriber.repository.SubscriberRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -19,10 +20,8 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.*;
 
-
 @DataJpaTest
 @Transactional
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ProblemRepositoryTest {
     @Autowired
     private ProblemRepository problemRepository;
@@ -36,35 +35,54 @@ class ProblemRepositoryTest {
     @Mock
     private MailService mailService;
 
-    @Test
-    @DisplayName("구독자의 선호 티어와 태그에 맞는 문제 조회 테스트")
-    void findProblemsBySubscriberPreferences() {
-        // given
+    private Tag tag1;
+    private Tag tag2;
+    private Tag tag3;
+    private Subscriber subscriber;
+    private Problem problem1;
+    private Problem problem2;
+    private Problem problem3;
+    private Problem problem4;
+
+    @BeforeEach
+    void setUp() {
         // 1. 태그 생성
-        Tag tag1 = new Tag("구현", "implementation");
-        Tag tag2 = new Tag("그리디", "greedy");
+        tag1 = new Tag("구현", "implementation");
+        tag2 = new Tag("그리디", "greedy");
+        tag3 = new Tag("수학", "math");
         tagRepository.save(tag1);
         tagRepository.save(tag2);
+        tagRepository.save(tag3);
 
         // 2. 구독자 생성 및 선호 설정
-        Subscriber subscriber = new Subscriber("test@example.com", new TierPreference(1, 5)); // Bronze V ~ Bronze I
+        subscriber = new Subscriber("test@example.com", new TierPreference(1, 5)); // Bronze V ~ Bronze I
+
         subscriber.addTagPreference(tag1);
         subscriber.addTagPreference(tag2);
+
         subscriberRepository.save(subscriber);
 
         // 3. 문제 생성
-        Problem problem1 = new Problem(1L, "문제1", 1); // Bronze V
+        problem1 = new Problem(1L, "문제1",  1); // Bronze V
         problem1.addTag(tag1);
         problemRepository.save(problem1);
 
-        Problem problem2 = new Problem(2L, "문제2", 3); // Bronze III
+        problem2 = new Problem(2L, "문제2",  3); // Bronze III
         problem2.addTag(tag2);
         problemRepository.save(problem2);
 
-        Problem problem3 = new Problem(3L, "문제3", 6); // Silver V (선호 티어 범위 밖)
+        problem3 = new Problem(3L, "문제3", 6); // Silver V (선호 티어 범위 밖)
         problem3.addTag(tag1);
         problemRepository.save(problem3);
 
+        problem4 = new Problem(4L, "문제4",  4); // Bronze II
+        problem4.addTag(tag3);
+        problemRepository.save(problem4);
+    }
+
+    @Test
+    @DisplayName("구독자의 선호 티어와 태그에 맞는 문제 조회 테스트")
+    void findProblemsBySubscriberPreferences() {
         // when
         List<Problem> problems = problemRepository.findProblemsBySubscriberPreferences(
                 subscriber.getTierPreference().getMinTier(),
@@ -86,5 +104,60 @@ class ProblemRepositoryTest {
                     .collect(Collectors.toList()))
                     .containsAnyOf("구현", "그리디");
         }
+    }
+
+    @Test
+    @DisplayName("구독자의 선호 태그만으로 문제 조회 테스트")
+    void findByTagPreferences() {
+        // when
+        List<Problem> problems = problemRepository.findByTagPreferences(subscriber.getId());
+
+        // then
+        assertThat(problems).hasSize(3); // 구현 태그와 그리디 태그를 가진 문제들
+        assertThat(problems).extracting("problemId")
+                .containsExactlyInAnyOrder(1L, 2L, 3L);
+
+        // 각 문제의 태그 확인
+        for (Problem problem : problems) {
+            assertThat(problem.getProblemTags()).isNotEmpty();
+
+            assertThat(problem.getProblemTags().stream()
+                    .map(pt -> pt.getTag().getDisplayName())
+                    .collect(Collectors.toList()))
+                    .containsAnyOf("구현", "그리디");
+        }
+    }
+
+    @Test
+    @DisplayName("티어 범위로 문제 조회 테스트")
+    void findByLevelBetween() {
+        // when
+        List<Problem> problems = problemRepository.findByLevelBetween(1, 5);
+
+        // then
+        assertThat(problems).hasSize(3); // Bronze V ~ Bronze I 범위 내 문제들
+        assertThat(problems).extracting("problemId")
+                .containsExactlyInAnyOrder(1L, 2L, 4L);
+
+        // 각 문제의 레벨 확인
+        for (Problem problem : problems) {
+            assertThat(problem.getLevel()).isBetween(1, 5);
+        }
+    }
+
+    @Test
+    @DisplayName("모든 경우의 수 확인 테스트")
+    void findProblemsWithDifferentConditions() {
+        // 1. 티어와 태그 모두 일치하는 경우
+        List<Problem> bothMatch = problemRepository.findProblemsBySubscriberPreferences(1, 5, subscriber.getId());
+        assertThat(bothMatch).extracting("problemId").containsExactlyInAnyOrder(1L, 2L);
+
+        // 2. 티어만 일치하는 경우 (수학 태그는 선호 태그에 없음)
+        List<Problem> onlyTierMatch = problemRepository.findByLevelBetween(1, 5);
+        assertThat(onlyTierMatch).extracting("problemId").containsExactlyInAnyOrder(1L, 2L, 4L);
+
+        // 3. 태그만 일치하는 경우 (Silver V는 선호 티어 범위 밖)
+        List<Problem> onlyTagMatch = problemRepository.findByTagPreferences(subscriber.getId());
+        assertThat(onlyTagMatch).extracting("problemId").containsExactlyInAnyOrder(1L, 2L, 3L);
     }
 }

--- a/src/test/java/org/janggo/pseveryday/util/TestSubscriberGenerator.java
+++ b/src/test/java/org/janggo/pseveryday/util/TestSubscriberGenerator.java
@@ -1,0 +1,53 @@
+package org.janggo.pseveryday.util;
+
+import lombok.RequiredArgsConstructor;
+import org.janggo.pseveryday.domain.problem.entity.Tag;
+import org.janggo.pseveryday.domain.problem.repository.TagRepository;
+import org.janggo.pseveryday.domain.subscriber.entity.Subscriber;
+import org.janggo.pseveryday.domain.subscriber.entity.TagPreference;
+import org.janggo.pseveryday.domain.subscriber.entity.TierPreference;
+import org.janggo.pseveryday.domain.subscriber.repository.SubscriberRepository;
+import org.janggo.pseveryday.domain.subscriber.repository.TagPreferenceRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+@Component
+@RequiredArgsConstructor
+public class TestSubscriberGenerator {
+    private final SubscriberRepository subscriberRepository;
+    private final TagRepository tagRepository;
+    private final TagPreferenceRepository tagPreferenceRepository;
+
+    public void generateTestSubscribers(int count) {
+        List<Tag> allTags = tagRepository.findAll();
+        Random random = new Random();
+
+        List<Subscriber> subscribers = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            Subscriber subscriber = new Subscriber("test_user_" + i + "@example.com", new TierPreference(1,30));
+
+            // 50%의 확률로 티어 선호도 설정
+            if (random.nextBoolean()) {
+                int minTier = random.nextInt(20) + 1; // 1~20 사이 랜덤 티어
+                int maxTier = Math.min(30, minTier + random.nextInt(10) + 1);
+                subscriber.updateTierPreference(new TierPreference(minTier, maxTier));
+            }
+
+            int tagCount = random.nextInt(6); // 0~5개 태그
+            if (tagCount > 0) {
+                Collections.shuffle(allTags);
+                List<Tag> selectedTags = allTags.subList(0, Math.min(tagCount, allTags.size()));
+                subscriber.setTagPreferences(selectedTags);
+            }
+
+            subscribers.add(subscriber);
+
+        }
+        // 벌크 저장
+        subscriberRepository.saveAll(subscribers);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,8 +1,6 @@
 spring:
   application:
     name: ps-everyday
-  profiles:
-    active: local
   datasource:
     url: jdbc:mysql://${ps.db.endpoint}/${ps.db.dbname}?useSSL=false&serverTimezone=Asia/Seoul
     username: ${MYSQL_USERNAME}
@@ -14,17 +12,18 @@ spring:
     show-sql: true
 
   mail:
-    host: smtp.naver.com
-    port: 465
-    username: ${mail-username}
-    password: ${mail-password}
+    host: localhost
+    port: 8025
+    username:
+    password:
     properties:
       mail:
         smtp:
-          auth: true
+          auth: false
           ssl:
-            enable: true
-            trust: smtp.naver.com
+            enable: false
+          starttls:
+            enable: false
 
 
 boj:


### PR DESCRIPTION
### 변경 사항 요약
* 문제 필터링 로직 개선: 구독자의 선호 티어 및 태그를 기반으로 문제를 필터링하는 로직 개선

* N+1 문제 해결: ProblemRepository에서 연관 엔티티는 함께 조회하도록 수정하여, N+1 문제를 해결

* 이메일 발송 비동기 처리: MailService의 sendProblemMail 메서드에 `@Async` 어노테이션을 적용하여, 이메일 발송을 비동기적으로 처리

구독자 수 | 기존 처리 시간 | `@Async` 적용 후 | N+1 해결 + `@Async`적용 후
-- | -- | -- | --
10명 | 4.45초 | 5.14초 | 3.45초
100명 | 27.67초 | 24.29초 | 18.51초
1000명 | 200.79초 | 168.63초 | 158.40초

> 참고: 성능 측정은 System.currentTimeMillis()를 사용하여 수행되었으며, 경향만 파악하는 용도이고
더욱 정밀한 테스트 방법을 알아봐야 할 듯 함